### PR TITLE
Update replicas to 3

### DIFF
--- a/6/deployment-httpserver-rollingupdate.yaml
+++ b/6/deployment-httpserver-rollingupdate.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: httpserver
 spec:
-  replicas: 4
+  replicas: 3
   selector:
     matchLabels:
       app: httpserver

--- a/6/deployment-httpserver.yaml
+++ b/6/deployment-httpserver.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: httpserver
 spec:
-  replicas: 4
+  replicas: 3
   selector:
     matchLabels:
       app: httpserver


### PR DESCRIPTION
レプリカ数が3つの方がRolling Updateの挙動の説明がしやすいため、変更する。