### PR TITLE
Enable httpserver to get response message from volume

### DIFF
--- a/docker/main.go
+++ b/docker/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 )
+
+const defaultMessage = "Hello, world!"
 
 func main() {
 	port := os.Getenv("PORT")
@@ -13,14 +16,31 @@ func main() {
 		port = "8080"
 	}
 
+	message, err := readMessageFromConfig()
+	if err != nil {
+		log.Fatalf("Failed to read message from config: %v", err)
+		message = defaultMessage
+	}
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "Hello, world! Let's learn Kubernetes!")
+		fmt.Fprintf(w, message)
 	})
 
 	log.Printf("Starting server on port %s\n", port)
-	err := http.ListenAndServe(":"+port, nil)
+	err = http.ListenAndServe(":"+port, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
+func readMessageFromConfig() (string, error) {
+	configDir := "/etc/config"
+	configPath := fmt.Sprintf("%s/myconfig.txt", configDir)
+
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return defaultMessage, nil
+	}
+
+	return string(data), nil
+}


### PR DESCRIPTION
ConfigMapをVolumeから読み込むというハンズオンのため、修正を行いました。
このVolumeの使い方はあまり現実的ではないと思うので、
このハンズオン以外では1.0.0を利用することが推奨されます。