### PR TITLE
Add budybox container for chapter-7 probe handson manifest

### DIFF
--- a/7/deployment-disruption.yaml
+++ b/7/deployment-disruption.yaml
@@ -31,4 +31,9 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
+      - name: busybox
+        image: busybox:1.36.1
+        command:
+        - sleep
+        - "9999"
 


### PR DESCRIPTION
httpserverコンテナがReadyにならないハンズオンマニフェストの修正。
2つコンテナがあった方が片方失敗していることに気づきにくいため、コンテナを追加しました。